### PR TITLE
Refractor docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,8 +23,7 @@ services:
       - BACKEND_DNS=backend
 
   backend:
-    build:
-      context: ./backend
+    image: backend-image
     ports:
       - "9000:9000"
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - "6380:6380"
     volumes:
       - redis-data:/data
-    command: redis-server --appendonly yes
+    
     networks:            
       - backendnetwork   
   frontend:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,7 @@ services:
     networks:            
       - backendnetwork   
   frontend:
-    build:
-      context: ./frontend
+    image: frontend-image
     ports:
       - "8080:8080"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,9 @@ services:
       - backendnetwork
     environment:
       - REDIS_DNS=redis-backend
+    depends_on:
+      - redis
+    
 networks:
   backendnetwork:
 volumes:


### PR DESCRIPTION
A small refractor of the docker-compose file to include the images of the frontend and backend, instead of building them.